### PR TITLE
Fix the WebDAV URL discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # GoodData CL Change Log
 
+## 1.3.0
+
+* Removed deprecated command line arguments for the FTP host and port. The WebDAV endpoint is discovered at runtime via the REST API.
+
 ## 1.1.9-beta
 
 * Authentication handling updated to be forward compatible with API change in the upcoming

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cl-backend</artifactId>

--- a/backend/src/main/java/com/gooddata/integration/rest/GdcRESTApiWrapper.java
+++ b/backend/src/main/java/com/gooddata/integration/rest/GdcRESTApiWrapper.java
@@ -29,7 +29,6 @@ import com.gooddata.integration.model.Column;
 import com.gooddata.integration.model.Project;
 import com.gooddata.integration.model.SLI;
 import com.gooddata.integration.rest.configuration.NamePasswordConfiguration;
-import com.gooddata.util.FileUtil;
 import com.gooddata.util.NetUtil;
 
 import net.sf.json.JSON;
@@ -102,7 +101,7 @@ public class GdcRESTApiWrapper {
     public static final String LINKS_UPLOADS_KEY = "uploads";
 
     public static final String DLI_MANIFEST_FILENAME = "upload_info.json";
-    
+
     public static final String QUERY_PROJECTDASHBOARDS = "projectdashboards";
     public static final String QUERY_FOLDERS = "folders";
     public static final String QUERY_DATASETS = "datasets";
@@ -1811,7 +1810,7 @@ public class GdcRESTApiWrapper {
 		public void setEmail(String email) {
 			this.email = email;
 		}
-		
+
 		@Override
         public String toString() {
             return "DWGdcUser [getLogin()=" + getLogin() + ", getUri()=" + getUri() + ", getStatus()=" + getStatus()
@@ -3129,7 +3128,7 @@ public class GdcRESTApiWrapper {
         request.setRequestHeader("Content-Type", "application/json; charset=utf-8");
         request.setRequestHeader("Accept", "application/json");
         request.setRequestHeader("Accept-Charset", "utf-u");
-        request.setRequestHeader("User-Agent", "GoodData CL/1.2.73");
+        request.setRequestHeader("User-Agent", "GoodData CL/1.3.0");
         request.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
         return request;
     }
@@ -3141,10 +3140,10 @@ public class GdcRESTApiWrapper {
             super.finalize();
         }
     }
-    
+
     /**
      * API for querying users in a domain
-     * 
+     *
      * @param domain
      * @return
      */
@@ -3303,7 +3302,7 @@ public class GdcRESTApiWrapper {
     /**
      * Checks if report copying is finished. Workaround implementation due to
      * wrong handling of status code.
-     * 
+     *
      * @param link
      *            the link returned from the start loading
      * @return the loading status
@@ -3341,11 +3340,11 @@ public class GdcRESTApiWrapper {
 	    ptm.releaseConnection();
 	}
     }
-    
+
 
     /**
      * Retrieves the project info by the project's name
-     * 
+     *
      * @param name
      *            the project name
      * @return the GoodDataProjectInfo populated with the project's information
@@ -3377,7 +3376,7 @@ public class GdcRESTApiWrapper {
 
     /**
      * Returns the existing projects links
-     * 
+     *
      * @return accessible projects links
      * @throws com.gooddata.exception.HttpMethodException
      */
@@ -3400,7 +3399,7 @@ public class GdcRESTApiWrapper {
 
     /**
      * Create a new GoodData project
-     * 
+     *
      * @param name
      *            project name
      * @param desc
@@ -3415,11 +3414,11 @@ public class GdcRESTApiWrapper {
 	    throws GdcRestApiException {
 	    return this.createProject(name, desc, templateUri, null, null);
     }
-    
+
     /**
      * Returns the List of GoodDataProjectInfo structures for the accessible
      * projects
-     * 
+     *
      * @return the List of GoodDataProjectInfo structures for the accessible
      *         projects
      * @throws HttpMethodException

--- a/backend/src/main/java/com/gooddata/processor/CliParams.java
+++ b/backend/src/main/java/com/gooddata/processor/CliParams.java
@@ -36,9 +36,7 @@ import java.util.HashMap;
  */
 public class CliParams extends HashMap<String, String> {
 
-
     private NamePasswordConfiguration httpConfig = null;
-    private NamePasswordConfiguration ftpConfig = null;
 
     private static Logger l = Logger.getLogger(CliParams.class);
 
@@ -58,23 +56,5 @@ public class CliParams extends HashMap<String, String> {
      */
     public void setHttpConfig(NamePasswordConfiguration httpConfig) {
         this.httpConfig = httpConfig;
-    }
-
-    /**
-     * FTP config getter
-     *
-     * @return FTP config
-     */
-    public NamePasswordConfiguration getFtpConfig() {
-        return ftpConfig;
-    }
-
-    /**
-     * FTP config setter
-     *
-     * @param ftpConfig FTP config
-     */
-    public void setFtpConfig(NamePasswordConfiguration ftpConfig) {
-        this.ftpConfig = ftpConfig;
     }
 }

--- a/backend/src/main/java/com/gooddata/processor/ProcessingContext.java
+++ b/backend/src/main/java/com/gooddata/processor/ProcessingContext.java
@@ -50,7 +50,7 @@ public class ProcessingContext {
     private String projectId;
     private Connector connector;
     private GdcRESTApiWrapper _restApi = null;
-    private GdcDataTransferAPI _ftpApi = null;
+    private GdcDataTransferAPI webDAVApiWrapper = null;
 
 
     public String getProjectId() throws InvalidParameterException {
@@ -109,22 +109,15 @@ public class ProcessingContext {
     }
 
     public GdcDataTransferAPI getFtpApi(CliParams cliParams) {
-        if (_ftpApi == null) {
-            NamePasswordConfiguration ftpConfig = cliParams.getFtpConfig();
-            String host = ftpConfig.getGdcHost();
-            int port = ftpConfig.getPort();
-            if(host == null || host.length() <= 0) {
-                GdcRESTApiWrapper rest = getRestApi(cliParams);
-                URL url = rest.getWebDavURL();
-                ftpConfig.setGdcHost(url.getHost());
-                ftpConfig.setProtocol(url.getProtocol());
-                ftpConfig.setPort(url.getPort());
-            }
-            checkConfig(ftpConfig);
-            l.debug("Using the GoodData data stage host '" + ftpConfig.getGdcHost() + "'.");
-            _ftpApi = new GdcWebDavApiWrapper(ftpConfig);
+        if (webDAVApiWrapper == null) {
+            GdcRESTApiWrapper rest = getRestApi(cliParams);
+            URL url = rest.getWebDavURL();
+            NamePasswordConfiguration httpConfig = cliParams.getHttpConfig();
+            checkConfig(httpConfig);
+            l.debug("Using the GoodData data stage host '" + url + "'.");
+            webDAVApiWrapper = new GdcWebDavApiWrapper(httpConfig.getUsername(), httpConfig.getPassword(), url);
         }
-        return _ftpApi;
+        return webDAVApiWrapper;
     }
 
     private static void checkConfig(NamePasswordConfiguration config) {

--- a/cli-distro/pom.xml
+++ b/cli-distro/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cli</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cl-cli</artifactId>

--- a/cli/src/main/java/com/gooddata/processor/CreateZendeskV3Projects.java
+++ b/cli/src/main/java/com/gooddata/processor/CreateZendeskV3Projects.java
@@ -36,7 +36,6 @@ import org.apache.commons.cli.*;
 import org.apache.log4j.Logger;
 
 import java.io.*;
-import java.sql.SQLException;
 import java.util.*;
 
 /**
@@ -268,7 +267,7 @@ public class CreateZendeskV3Projects {
         CliParams cp = new CliParams();
 
         if (cp.containsKey(CLI_PARAM_VERSION[0])) {
-            l.info("GoodData CL version 1.2.73");
+            l.info("GoodData CL version 1.3.0");
             System.exit(0);
         }
 

--- a/cli/src/main/java/com/gooddata/processor/GdcDI.java
+++ b/cli/src/main/java/com/gooddata/processor/GdcDI.java
@@ -32,7 +32,6 @@ import com.gooddata.integration.rest.GdcRESTApiWrapper;
 import com.gooddata.integration.rest.MetadataObject;
 import com.gooddata.integration.rest.configuration.NamePasswordConfiguration;
 import com.gooddata.modeling.model.SourceSchema;
-import com.gooddata.naming.N;
 import com.gooddata.processor.parser.DIScriptParser;
 import com.gooddata.processor.parser.ParseException;
 import com.gooddata.util.DatabaseToCsv;
@@ -40,7 +39,6 @@ import com.gooddata.util.FileUtil;
 import com.gooddata.util.StringUtil;
 import org.apache.commons.cli.*;
 import org.apache.log4j.Logger;
-import org.apache.log4j.PropertyConfigurator;
 import org.joda.time.DateTimeZone;
 
 import java.io.*;
@@ -67,7 +65,6 @@ public class GdcDI implements Executor {
     public static String[] CLI_PARAM_PASSWORD = {"password", "p"};
 
     public static String[] CLI_PARAM_HOST = {"host", "h"};
-    public static String[] CLI_PARAM_FTP_HOST = {"ftphost", "f"};
     public static String[] CLI_PARAM_PROJECT = {"project", "i"};
     public static String[] CLI_PARAM_PROTO = {"proto", "t"};
     public static String[] CLI_PARAM_INSECURE = {"insecure", "s"};
@@ -77,7 +74,6 @@ public class GdcDI implements Executor {
     public static String[] CLI_PARAM_HTTP_PROXY_HOST = {"proxyhost", "K"};
     public static String[] CLI_PARAM_HTTP_PROXY_PORT = {"proxyport", "L"};
     public static String[] CLI_PARAM_HTTP_PORT = {"port", "S"};
-    public static String[] CLI_PARAM_FTP_PORT = {"ftpport", "O"};
     public static String[] CLI_PARAM_HTTP_PROXY_USERNAME = {"proxyusername", "U"};
     public static String[] CLI_PARAM_HTTP_PROXY_PASSWORD = {"proxypassword", "P"};
     public static String[] CLI_PARAM_TIMEZONE = {"timezone", "T"};
@@ -96,11 +92,9 @@ public class GdcDI implements Executor {
             new Option(CLI_PARAM_HTTP_PROXY_HOST[1], CLI_PARAM_HTTP_PROXY_HOST[0], true, "HTTP proxy hostname."),
             new Option(CLI_PARAM_HTTP_PROXY_PORT[1], CLI_PARAM_HTTP_PROXY_PORT[0], true, "HTTP proxy port."),
             new Option(CLI_PARAM_HTTP_PORT[1], CLI_PARAM_HTTP_PORT[0], true, "HTTP port."),
-            new Option(CLI_PARAM_FTP_PORT[1], CLI_PARAM_FTP_PORT[0], true, "Data stage port (deprecated)"),
             new Option(CLI_PARAM_HTTP_PROXY_USERNAME[1], CLI_PARAM_HTTP_PROXY_USERNAME[0], true, "HTTP proxy username."),
             new Option(CLI_PARAM_HTTP_PROXY_PASSWORD[1], CLI_PARAM_HTTP_PROXY_PASSWORD[0], true, "HTTP proxy password."),
             new Option(CLI_PARAM_HOST[1], CLI_PARAM_HOST[0], true, "GoodData host"),
-            new Option(CLI_PARAM_FTP_HOST[1], CLI_PARAM_FTP_HOST[0], true, "GoodData data stage host (deprecated)"),
             new Option(CLI_PARAM_PROJECT[1], CLI_PARAM_PROJECT[0], true, "GoodData project identifier (a string like nszfbgkr75otujmc4smtl6rf5pnmz9yl)"),
             new Option(CLI_PARAM_PROTO[1], CLI_PARAM_PROTO[0], true, "HTTP or HTTPS (deprecated)"),
             new Option(CLI_PARAM_INSECURE[1], CLI_PARAM_INSECURE[0], false, "Disable encryption"),
@@ -159,27 +153,6 @@ public class GdcDI implements Executor {
                 cliParams.setHttpConfig(new NamePasswordConfiguration(
                         cliParams.containsKey(CLI_PARAM_INSECURE[0]) ? "http" : "https",
                         cliParams.get(CLI_PARAM_HOST[0]),
-                        cliParams.get(CLI_PARAM_USERNAME[0]), cliParams.get(CLI_PARAM_PASSWORD[0])));
-            }
-
-            if(cliParams.containsKey(CLI_PARAM_FTP_PORT[0])) {
-                String ftpPortString = cliParams.get(CLI_PARAM_FTP_PORT[0]);
-                int ftpPort = 0;
-                try {
-                    ftpPort = Integer.parseInt(ftpPortString);
-                }
-                catch(NumberFormatException e) {
-                    throw new InvalidArgumentException("Invalid WebDav port value: '" + ftpPortString+"'.");
-                }
-                cliParams.setFtpConfig(new NamePasswordConfiguration(
-                        cliParams.containsKey(CLI_PARAM_INSECURE[0]) ? "http" : "https",
-                        cliParams.get(CLI_PARAM_FTP_HOST[0]),
-                        cliParams.get(CLI_PARAM_USERNAME[0]), cliParams.get(CLI_PARAM_PASSWORD[0]),ftpPort));
-            }
-            else {
-                cliParams.setFtpConfig(new NamePasswordConfiguration(
-                        cliParams.containsKey(CLI_PARAM_INSECURE[0]) ? "http" : "https",
-                        cliParams.get(CLI_PARAM_FTP_HOST[0]),
                         cliParams.get(CLI_PARAM_USERNAME[0]), cliParams.get(CLI_PARAM_PASSWORD[0])));
             }
 
@@ -387,7 +360,7 @@ public class GdcDI implements Executor {
 
         if (cp.containsKey(CLI_PARAM_VERSION[0])) {
 
-            l.info("GoodData CL version 1.2.73" +
+            l.info("GoodData CL version 1.3.0" +
                     ((BUILD_NUMBER.length() > 0) ? ", build " + BUILD_NUMBER : "."));
             System.exit(0);
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cl-common</artifactId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cl-connector</artifactId>

--- a/connector/src/main/java/com/gooddata/chargify/ChargifyWrapper.java
+++ b/connector/src/main/java/com/gooddata/chargify/ChargifyWrapper.java
@@ -241,7 +241,7 @@ public class ChargifyWrapper {
     private static <T extends HttpMethod> T configureHttpMethod(T request) {
         request.setRequestHeader("Content-Type", "text/xml");
         request.setRequestHeader("Accept", "text/xml");
-        request.setRequestHeader("User-Agent", "GoodData CL/1.2.73");
+        request.setRequestHeader("User-Agent", "GoodData CL/1.3.0");
         return request;
     }
 

--- a/notification-distro/pom.xml
+++ b/notification-distro/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-alert</artifactId>

--- a/notification/pom.xml
+++ b/notification/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-notification</artifactId>

--- a/notification/src/main/java/com/gooddata/processor/GdcNotification.java
+++ b/notification/src/main/java/com/gooddata/processor/GdcNotification.java
@@ -371,7 +371,7 @@ public class GdcNotification {
         }
 
         if (cp.containsKey(CLI_PARAM_VERSION[0])) {
-            l.info("GoodData Notification Tool version 1.2.73" +
+            l.info("GoodData Notification Tool version 1.3.0" +
                     ((BUILD_NUMBER.length() > 0) ? ", build " + BUILD_NUMBER : "."));
             System.exit(0);
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>com.gooddata.cl</groupId>
     <artifactId>gooddata-cl</artifactId>
-    <version>1.2.73</version>
+    <version>1.3.0</version>
     <name>gooddata-cl</name>
     <description>GoodData CL command line tool and Java API framework.</description>
     <url>http://developer.gooddata.com</url>

--- a/sfdc/pom.xml
+++ b/sfdc/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-sfdc-lib</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.gooddata.cl</groupId>
         <artifactId>gooddata-cl</artifactId>
-        <version>1.2.73</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>gooddata-cl-web</artifactId>


### PR DESCRIPTION
Prior to this commit the WebDAV URL was constructed from the server hostname
(returned by the API) and the constant /uploads. It doesn't work longer,
because the API returns new WebDAV URL which is <hostname>/gdc/uploads. This fix
ensures the WebDAV URL is discovered from the API at runtime.