### PR TITLE
Fix javadoc build on JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,27 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <!-- Setting more lax JavaDoc lint. See http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html-->
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <repositories>
         <repository>
             <releases>


### PR DESCRIPTION
This patch ensures the javadoc for GoodData CL tool is buildable on JDK 8.