### PR TITLE
BUGFIX GD-43509: Fix ETL pull log's URL construction

### DIFF
--- a/backend/src/main/java/com/gooddata/integration/webdav/GdcWebDavApiWrapper.java
+++ b/backend/src/main/java/com/gooddata/integration/webdav/GdcWebDavApiWrapper.java
@@ -121,7 +121,8 @@ public class GdcWebDavApiWrapper implements GdcDataTransferAPI {
         String[] files = ret.split(",");
         for (String file : files) {
             if (file.endsWith(".log") || file.endsWith(".json")) {
-                GetMethod get = new GetMethod(webdavURL.toString() + file);
+                final URL logURL = new URL(webdavURL.getProtocol(), webdavURL.getHost(), webdavURL.getPort(), file);
+                GetMethod get = new GetMethod(logURL.toString());
                 String content = executeMethodOk(get);
                 result.put(file, content);
             }


### PR DESCRIPTION
The WebDAV client returns relative paths to the server root therefore we cannot
use the full WebDAV URI returned by the discovery API.