### PR TITLE
Initializing DataTypeGuess so testIsDate can pass when run by itself

### DIFF
--- a/connector/src/test/java/com/gooddata/csv/DataTypeGuessTest.java
+++ b/connector/src/test/java/com/gooddata/csv/DataTypeGuessTest.java
@@ -53,6 +53,7 @@ public class DataTypeGuessTest extends TestCase {
     }
 
     public void testIsDate() {
+        DataTypeGuess guesser = new DataTypeGuess(true);
         assertEquals("yyyy-MM-dd", DataTypeGuess.getDateFormat("2010-11-12"));
         assertNull(DataTypeGuess.getDateFormat("2010-13-12"));
         assertEquals("MM/dd/yyyy", DataTypeGuess.getDateFormat("11/12/2010"));


### PR DESCRIPTION
Currently, test DataTypeGuessTest.testIsDate() fails when run by itself due to uninitialized DateTypeGuess.KNOWN_FORMATS. The proposed pull request creates a new DataTypeGuess instance at the beginning of test to ensure DateTypeGuess.KNOWN_FORMATS is initialized.

Please let me know if you want to discuss the changes more.